### PR TITLE
Fix occ db:convert-type, issue #26085

### DIFF
--- a/lib/private/DB/QueryBuilder/QuoteHelper.php
+++ b/lib/private/DB/QueryBuilder/QuoteHelper.php
@@ -57,6 +57,10 @@ class QuoteHelper {
 		if ($string === null || $string === 'null' || $string === '*') {
 			return $string;
 		}
+		
+		if ($string instanceof \Doctrine\DBAL\Schema\Column) {
+			return $string->getName();
+		}
 
 		if (!is_string($string)) {
 			throw new \InvalidArgumentException('Only strings, Literals and Parameters are allowed');


### PR DESCRIPTION
When using occ db:convert-type, the command fails with the following message:

```
Only strings, Literals and Parameters are allowed
```

This pull request fixes the error and resolves issue #26085 using the original poster's proposed solution.

---

Signed-off-by: Henry Jordan <hank@henryjordan.com>